### PR TITLE
group: add missing get-chat-window() method to custom-editor-canvs%

### DIFF
--- a/group.rkt
+++ b/group.rkt
@@ -614,6 +614,8 @@
                     this-min-height
                     this-vert-margin
                     this-chat-window)
+
+        (define/public (get-chat-window) this-chat-window)
         ; TODO:
         ; unicode?
         ; wheel-up/wheel-down(?)


### PR DESCRIPTION
For focusing change to work since it relies on it.
