### PR TITLE
Adding basic error handling to GUI

### DIFF
--- a/blight.rkt
+++ b/blight.rkt
@@ -1281,6 +1281,14 @@ val is a value that corresponds to the value of the key
 (callback-group-action my-tox on-group-action)
 (callback-group-namelist-change my-tox on-group-namelist-change)
 
+(define cur-ctx (tox-ctx my-tox my-id-bytes clean-up))
+
+(define (blight-handle-exception unexn)
+  (let ([res (show-error-unhandled-exn unexn cur-ctx)])
+    (when (eq?  res 'quit)
+      (clean-up)
+      (exit))))
+
 ; tox loop that only uses tox_do and sleeps for some amount of time
 (define tox-loop-thread
   (thread
@@ -1294,10 +1302,3 @@ val is a value that corresponds to the value of the key
        (sleep (/ (tox-do-interval my-tox) 1000))
        (loop)))))
 
-(define cur-ctx (tox-ctx my-tox my-id-bytes tox-loop-thread clean-up))
-
-(define (blight-handle-exception unexn)
-  (let ([res (show-error-unhandled-exn unexn cur-ctx)])
-    (when (eq?  res 'quit)
-      (clean-up)
-      (exit))))

--- a/utils.rkt
+++ b/utils.rkt
@@ -5,7 +5,7 @@
 (require racket/gui)
 
 ;;; TODO: use structure type properties here
-(define-struct tox-ctx (my-tox my-id-bytes f-loopthread f-cleanup)
+(define-struct tox-ctx (my-tox my-id-bytes  f-cleanup)
   #:transparent)
 
 (define (repeat proc times)


### PR DESCRIPTION
Sometimes blight silently throws exception, leaving GUI in inconsistent state and without any notices, so you might lose messages you are going to send.

This PR adds handling of top-level uncaught exceptions to GUI, showing a dialog box with some context.
Debugging output to console is preserved.

For that purpose i almost completely wrapped all blight.rkt in blight-run function and added some context passing to error dialog (added to utils.rkt)

For now exceptions generated during blight-run() (the initialization) are not handled, because we need to split it to multiple sequential calls (like read-data(), connect(), init-gui(), bootsrap() etc).

A screenshot
![image](http://dump.bitcheese.net/images/upavupu/blight-error.png)
